### PR TITLE
change url from packages.sw.be to apt.sw.be

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -8,7 +8,7 @@
 
 
 - name: install yum rpmforge repo
-  yum: name=http://packages.sw.be/rpmforge-release/rpmforge-release-0.5.2-2.el6.rf.i686.rpm
+  yum: name=http://apt.sw.be/redhat/el6/en/i386/dag/RPMS/rpmforge-release-0.5.2-2.el6.rf.i686.rpm
     state=present
   tags:
     - rpmforge_repo


### PR DESCRIPTION
old url http://packages.sw.be/rpmforge-release/rpmforge-release-0.5.2-2.el6.rf.i686.rpm wasn't reachable so change to 
http://apt.sw.be/redhat/el6/en/i386/dag/RPMS/rpmforge-release-0.5.2-2.el6.rf.i686.rpm which apparently is the is the new RPMforge
